### PR TITLE
Options panel (sliders), configurable timers, global chat throttling, and “Options” button in the MultiBot bar

### DIFF
--- a/MultiBot.lua
+++ b/MultiBot.lua
@@ -1076,10 +1076,43 @@ MultiBot.tips.units.alliance =
 "|cffff0000Right-Click to bring all Group-Members offline|r\n"..
 "|cff999999(Execution-Order: System)|r";
 
--- MAIN --
+-- SLIDERS INTERFACE --
+MultiBot.tips.sliders = {}
 
+MultiBot.tips.sliders.throttleinstalled =
+"MultiBot throttle installed";
+
+MultiBot.tips.sliders.frametitle =
+"MultiBot — Options";
+
+MultiBot.tips.sliders.actionsinter =
+"Automatic action intervals";
+
+MultiBot.tips.sliders.statsinter =
+"Stats ping interval";
+
+MultiBot.tips.sliders.talentsinter =
+"Auto talents interval";
+
+MultiBot.tips.sliders.invitsinter =
+"Invitation loop interval";
+
+MultiBot.tips.sliders.sortinter =
+"Sorting/refresh interval";
+
+MultiBot.tips.sliders.messpersec =
+"Messages per second";
+
+MultiBot.tips.sliders.maxburst =
+"Maximum burst";
+
+MultiBot.tips.sliders.rstbutn =
+"Reset";
+
+-- MAIN --
 MultiBot.tips.main = {}
 MultiBot.tips.main.lang = {}
+
 MultiBot.tips.main.master =
 "Main-Control\n|cffffffff"..
 "In this Control you will find the Auto-Switches and Reset-Commands.\n"..
@@ -1088,6 +1121,14 @@ MultiBot.tips.main.master =
 "|cff999999(Execution-Order: System)|r\n\n"..
 "|cffff0000Right-Click to drag and move MultiBot|r\n"..
 "|cff999999(Execution-Order: System)|r";
+
+MultiBot.tips.main.options =
+"Options-Switch\n|cffffffff"..
+"Opens the MultiBot settings panel with sliders for action intervals.\n"..
+"(Stats / Talents / Invite / Sort) and chat throttling (Messages per second / Burst).\n"..
+"Settings are saved per character.|r\n\n"..
+"|cffff0000Left-Click to open or close the options panel|r\n"..
+"|cff999999(Execution-Order: Interface)|r";
 
 MultiBot.tips.main.coords =
 "Reset-Coords\n|cffffffff"..
@@ -1130,36 +1171,6 @@ MultiBot.tips.main.beast =
 "White Fang must be placed into the World by the GameMaster.|r\n\n"..
 "|cffff0000Left-Click to enable or disable the Beastmaster-Control|r\n"..
 "|cff999999(Execution-Order: System)|r";
-
---[[
-MultiBot.tips.main.lang.master =
-"Language-Selector|cffffffff\n"..
-"This Control allows you to select the Language of MultiBot.\n"..
-"If this control is active, MultiBot can have a different Language than the Client.\n"..
-"The Execution-Order shows the Receiver for Commandos.|r\n\n"..
-"|cffff0000Left-Click to show or hide the Options|r\n"..
-"|cff999999(Execution-Order: System)|r\n\n"..
-"|cffff0000Right-Click to enable or disable the Language-Selector|r\n"..
-"|cff999999(Execution-Order: System)|r";
-
-MultiBot.tips.main.lang.deDE =
-"Deutsch|cffffffff\n"..
-"Wenn du dies lesen kannst ist dies wahrscheinlich die richtige Sprache für dich.|r\n\n"..
-"|cffff0000Linksklicken um Deutsch auszuwählen|r\n"..
-"|cff999999(Execution-Order: System)|r";
-
-MultiBot.tips.main.lang.enGB =
-"British|cffffffff\n"..
-"If you can read this, this is probably the right Language for you.|r\n\n"..
-"|cffff0000Left-Click to select British|r\n"..
-"|cff999999(Execution-Order: System)|r";
-
-MultiBot.tips.main.lang.none =
-"English|cffffffff\n"..
-"If you can read this, this is probably the right Language for you.|r\n\n"..
-"|cffff0000Left-Click to select English|r\n"..
-"|cff999999(Execution-Order: System)|r";
-]]--
 
 MultiBot.tips.main.expand =
 "Expand-Switch\n|cffffffff"..

--- a/MultiBot.toc
+++ b/MultiBot.toc
@@ -3,10 +3,13 @@
 ## Title: MultiBot
 ## Notes: User Interface for Playerbot
 ## Author: Nico Löbbert
-## SavedVariablesPerCharacter: MultiBotSave
+## SavedVariablesPerCharacter: MultiBotSave, MultiBotDB
 ## SavedVariables: MultiBotGlobalSave
 
 MultiBot.lua
+MultiBotConfig.lua
+MultiBotOptions.lua
+MultiBotThrottle.lua
 
 MultiBotLanguage-deDE.lua
 MultiBotLanguage-enGB.lua

--- a/MultiBotConfig.lua
+++ b/MultiBotConfig.lua
@@ -1,0 +1,108 @@
+-- MultiBotConfig.lua
+-- print("MultiBotConfig.lua loaded")
+MultiBot = MultiBot or {}
+
+-- Valeurs d'origine (en secondes) : gardées à l'identique
+local DEFAULTS = {
+  stats  = 45, -- ping "stats"
+  talent = 3,  -- application auto des talents
+  invite = 5,  -- boucle d'invitations
+  sort   = 1,  -- tri/rafraîchissement
+}
+
+local THROTTLE_DEFAULTS = { 
+  rate = 5, 
+  burst = 8 
+}
+
+-- Assure l'existence de la SavedVariables et des clés
+function MultiBot.Config_Ensure()
+  MultiBotDB = MultiBotDB or {}
+
+  -- Timers
+  MultiBotDB.timers = MultiBotDB.timers or {}
+  for k, v in pairs(DEFAULTS) do
+    if type(MultiBotDB.timers[k]) ~= "number" or MultiBotDB.timers[k] <= 0 then
+      MultiBotDB.timers[k] = v
+    end
+  end
+
+  -- Throttle (DB)
+  MultiBotDB.throttle = MultiBotDB.throttle or {}
+  if type(MultiBotDB.throttle.rate) ~= "number" or MultiBotDB.throttle.rate <= 0 then
+    MultiBotDB.throttle.rate = THROTTLE_DEFAULTS.rate
+  end
+  if type(MultiBotDB.throttle.burst) ~= "number" or MultiBotDB.throttle.burst <= 0 then
+    MultiBotDB.throttle.burst = THROTTLE_DEFAULTS.burst
+  end
+end
+
+-- Recopie les valeurs sauvegardées vers les timers runtime
+function MultiBot.ApplyTimersToRuntime()
+  if not (MultiBot and MultiBot.timer) then return end
+  for k, v in pairs(MultiBotDB.timers or {}) do
+    MultiBot.timer[k] = MultiBot.timer[k] or { elapsed = 0, interval = v }
+    MultiBot.timer[k].interval = v
+  end
+end
+
+-- Lecture
+function MultiBot.GetTimer(name)
+  if MultiBotDB and MultiBotDB.timers then
+    return MultiBotDB.timers[name]
+  end
+  return DEFAULTS[name]
+end
+
+-- Réinitialise les compteurs elapsed (un ou tous)
+function MultiBot.ApplyTimerChanges(name)
+  if not (MultiBot and MultiBot.timer) then return end
+  local function resetOne(n)
+    if MultiBot.timer[n] and type(MultiBot.timer[n].elapsed) == "number" then
+      MultiBot.timer[n].elapsed = 0
+    end
+  end
+  if name then
+    resetOne(name)
+  else
+    resetOne("stats"); resetOne("talent"); resetOne("invite"); resetOne("sort")
+  end
+end
+
+-- Écriture + clamp + application immédiate
+function MultiBot.SetTimer(name, value)
+  if not (MultiBotDB and MultiBotDB.timers) then return end
+  if type(value) ~= "number" then return end
+  if value < 0.1 then value = 0.1 end
+  if value > 600 then value = 600 end
+  MultiBotDB.timers[name] = value
+
+  -- Applique au runtime si présent
+  if MultiBot and MultiBot.timer and MultiBot.timer[name] then
+    MultiBot.timer[name].interval = value
+  end
+  MultiBot.ApplyTimerChanges(name) -- remet elapsed=0 pour ce timer
+end
+
+-- Throttle: lecture
+function MultiBot.GetThrottleRate()  return (MultiBotDB and MultiBotDB.throttle and MultiBotDB.throttle.rate)  or 5 end
+function MultiBot.GetThrottleBurst() return (MultiBotDB and MultiBotDB.throttle and MultiBotDB.throttle.burst) or 8 end
+
+-- Throttle: écriture + application immédiate
+function MultiBot.SetThrottleRate(v)
+  if type(v) ~= "number" then return end
+  if v < 1 then v = 1 end
+  if v > 50 then v = 50 end
+  MultiBotDB.throttle = MultiBotDB.throttle or {}
+  MultiBotDB.throttle.rate = v
+  if MultiBot._ThrottleStats then MultiBot._ThrottleStats(MultiBotDB.throttle.rate, MultiBot.GetThrottleBurst()) end
+end
+
+function MultiBot.SetThrottleBurst(v)
+  if type(v) ~= "number" then return end
+  if v < 1 then v = 1 end
+  if v > 100 then v = 100 end
+  MultiBotDB.throttle = MultiBotDB.throttle or {}
+  MultiBotDB.throttle.burst = v
+  if MultiBot._ThrottleStats then MultiBot._ThrottleStats(MultiBot.GetThrottleRate(), MultiBotDB.throttle.burst) end
+end

--- a/MultiBotInit.lua
+++ b/MultiBotInit.lua
@@ -98,9 +98,7 @@ tButton.doLeft = function(pButton)
 	if(MultiBot.isTarget()) then MultiBot.ActionToGroup("@tank do attack my target") end
 end]]--
 
--- --------------------------------------------------------------------
 --  UI ATTACK REFORGED --
--- --------------------------------------------------------------------
 function MultiBot.BuildAttackUI(tLeft)
 
   -- 1. Table
@@ -1517,6 +1515,38 @@ end
 tMain.addButton("Actions", 0, 374, "inv_helmet_02", MultiBot.tips.main.action)
 .doLeft = function(pButton)
 	MultiBot.ActionToTargetOrGroup("reset")
+end
+
+-- [AJOUT] Bouton Options (ouvre/ferme le panneau des sliders)
+local tBtnOptions = tMain.addButton("Options", 0, 404, "inv_misc_gear_02", MultiBot.tips.main.options)
+tBtnOptions._active = false
+
+-- Grisé par défaut (alpha 0.4 + désaturation)
+do
+  local f = tBtnOptions.frame or tBtnOptions
+  if f and f.SetAlpha then f:SetAlpha(0.4) end
+  if f and f.GetRegions then
+    local tex = f:GetRegions()
+    if tex and tex.SetDesaturated then tex:SetDesaturated(true) end
+  end
+end
+
+tBtnOptions.doLeft = function(pButton)
+  -- Toggle panneau d'options
+  local opened = false
+  if MultiBot.ToggleOptionsPanel then
+    opened = MultiBot.ToggleOptionsPanel()
+  end
+
+  pButton._active = opened
+
+  -- Visuel : dégrise si ouvert, re-grise si fermé
+  local f = pButton.frame or pButton
+  if f and f.SetAlpha then f:SetAlpha(opened and 1.0 or 0.4) end
+  if f and f.GetRegions then
+    local tex = f:GetRegions()
+    if tex and tex.SetDesaturated then tex:SetDesaturated(not opened) end
+  end
 end
 
 --[[-- GAMEMASTER --

--- a/MultiBotLanguage-enGB.lua
+++ b/MultiBotLanguage-enGB.lua
@@ -1,6 +1,6 @@
 if(GetLocale() == "enGB") then
 MultiBot.data.classes.input = {
-[1] = "DeathKnight",
+[1] = "Death Knight",
 [2] = "Druid",
 [3] = "Hunter",
 [4] = "Mage",
@@ -11,6 +11,8 @@ MultiBot.data.classes.input = {
 [9] = "Warlock",
 [10] = "Warrior"
 }
+
+-- INFO --
 
 -- GLYPHS
 MultiBot.info.glyphssocketnotunlocked =
@@ -23,7 +25,7 @@ MultiBot.info.glyphsunknowglyph =
 "Unable to identify this glyph.";
 
 MultiBot.info.glyphsglyphtype =
-"Glyphe type ";
+"Glyph type ";
 
 MultiBot.info.glyphsglyphsocket =
 "wrong socket.";
@@ -40,7 +42,8 @@ MultiBot.info.glyphsglyphsfor =
 MultiBot.info.talentscustomtalentsfor =
 "Custom Talents for";
 
--- Hunters
+-- Hunter
+
 MultiBot.info.hunterpeteditentervalue =
 "Enter value";
 
@@ -59,39 +62,38 @@ MultiBot.info.hunterpetentersomething =
 MultiBot.info.hunterpetrandomfamily =
 "Random by Family";
 
--- end Hunters
+-- end Hunter
 
--- INFO --
 
 MultiBot.info.command =
 "Command not found.";
 
 MultiBot.info.target =
-"I dont have a Target.";
+"I don't have a target.";
 
 MultiBot.info.classes =
-"The Classes do not match.";
+"The Classes doesn't match.";
 
 MultiBot.info.levels =
-"The Levels do not match.";
+"Levels don't match.";
 
 MultiBot.info.spell =
-"I couldnt identify the Spell.";
+"I couldn't identify the spell.";
 
 MultiBot.info.macro =
-"I already have the maximum # of private Macros.";
+"I have already the maximum # of private macros.";
 
 MultiBot.info.neither =
-"I neither have a Target nor am I in a Raid or Party.";
+"I neither have a target, nor am I in a Raid or Party.";
 
 MultiBot.info.group =
-"I'm neither in a Raid nor in a Party.";
+"I neither am in a Raid nor in a Party.";
 
 MultiBot.info.inviting =
 "Inviting NAME to the Group.";
 
 MultiBot.info.combat =
-"Asked NAME for Combat-Strategies.";
+"Asked NAME for Combat Strategies.";
 
 MultiBot.info.teleport =
 "will teleport you to 'MAP - ZONE'";
@@ -106,49 +108,52 @@ MultiBot.info.spellbook =
 "Spellbook of NAME";
 
 MultiBot.info.player =
-"I wont Auto-Initialize 'NAME' from the Playerbot-Roster.";
+"I won't Auto-Initialize 'NAME' from the Playerbot-Roster.";
 
 MultiBot.info.member =
-"I wont Auto-Initialize 'NAME' from the Guild-Roster.";
+"I won't Auto-Initialize 'NAME' from the Guild-Roster.";
 
 MultiBot.info.players =
-"I wont Auto-Initialize anyone from the Playerbot-Roster.";
+"I won't Auto-Initialize anyone from the Playerbot-Roster.";
 
 MultiBot.info.members =
-"I wont Auto-Initialize anyone from the Guild-Roster.";
+"I won't Auto-Initialize anyone from the Guild-Roster.";
 
 MultiBot.info.wait =
-"I already invited Members, please wait until I am done.";
+"I've already invited members. Please wait until I'm done.";
 
 MultiBot.info.starting =
 "Starting to invite Members.";
 
 MultiBot.info.stats =
-"Auto-Stats is for Parties, not for a Raids.";
+"Auto-Stats is for Parties, not Raids.";
 
 MultiBot.info.location =
-"has no Location stored inside.";
+"has no Location stored within.";
 
 MultiBot.info.itlocation =
-"It has no Location stored inside.";
+"It has no Location stored within.";
 
 MultiBot.info.saving =
-"I am still in the process of saving my position.";
+"I'm still in the process of saving my position.";
 
 MultiBot.info.action =
-"I need to select a Action.";
+"I need to select an action.";
 
-MultiBot.info.combination = 
+MultiBot.info.combination =
 "There are no Items for this Combination.";
 
 --MultiBot.info.language =
 --"I need to activate the Language-Selector first.";
 
 MultiBot.info.rights =
-"I have not the GameMaster-Rights.";
+"I have no GameMaster privileges.";
 
 MultiBot.info.reward =
-"Select the Rewards";
+"Select Rewards";
+
+MultiBot.info.nothing =
+"Nothing is saved in this Slot.";
 
 MultiBot.info.shorts.bag =
 "Bag";
@@ -165,15 +170,15 @@ MultiBot.info.shorts.mp =
 -- INFO:TALENT --
 
 MultiBot.info.talent.Level =
-"His Level is lower than 10.";
+"Level is lower than 10.";
 
 MultiBot.info.talent.OutOfRange =
-"The Bot is out of Range.";
+"Bot is out of Range.";
 
-MultiBot.info.talent.Apply = 
+MultiBot.info.talent.Apply =
 "Apply";
 
-MultiBot.info.talent.Copy = 
+MultiBot.info.talent.Copy =
 "Copy";
 
 MultiBot.info.talent.Title =
@@ -275,73 +280,71 @@ MultiBot.info.talent.Warrior3 =
 -- MOVE --
 
 MultiBot.tips.move.inventory =
-"Right-Click to drag and move the Inventory";
+"Right-click to drag and move the Inventory";
 
 MultiBot.tips.move.stats =
-"Right-Click to drag and move Auto-Stats";
+"Right-click to drag and move Auto-Stats";
 
 MultiBot.tips.move.itemus =
-"Right-Click to drag and move Itemus";
+"Right-click to drag and move Itemus";
 
-MultiBot.tips.move.iconos = 
-"Right-Click to drag and move Iconos";
+MultiBot.tips.move.iconos =
+"Right-click to drag and move Iconos";
 
-MultiBot.tips.move.spellbook = 
-"Right-Click to drag and move the Spellbook";
+MultiBot.tips.move.spellbook =
+"Right-click to drag and move the Spellbook";
 
 MultiBot.tips.move.reward =
-"Right-Click to drag and move the Reward-Selector";
+"Right-click to drag and move the Reward-Selector";
 
 MultiBot.tips.move.talent =
-"Right-Click to drag and move the Talents";
+"Right-click to drag and move the Talents";
 
 MultiBot.tips.move.raidus =
-"Right-Click to drag and move the Raidus";
+"Right-click to drag and move the Raidus";
 
 -- TANKER --
 
-MultiBot.tips.tanker.master = 
+MultiBot.tips.tanker.master =
 "Tank-Attack\n|cffffffff"..
-"With this Button the Tanks will attack your target.\n"..
-"The Execution-Order shows the Receiver for Commands.|r\n\n"..
-"|cffff0000Left-Click to execute Tank-Attack|r\n"..
-"|cff999999(Execution-Order: Raid, Party)|r";
+"Control how Tanks attack.\n"..
+"|cffff0000Left-click to activate Tank-Attack|r\n"..
+"|cff999999(Executed by: Raid, Party)|r";
 
 -- ATTACK --
 
-MultiBot.tips.attack.master = 
+MultiBot.tips.attack.master =
 "Attack-Control\n|cffffffff"..
-"With this Control you can give the Command to attack.\n"..
-"Right-Click the Options to define a new default Action.\n"..
-"The Execution-Order shows the Receiver for Commands.|r\n\n"..
-"|cffff0000Left-Click to execute the default Action|r\n"..
-"|cff999999(Execution-Order: Raid, Party)|r\n\n"..
-"|cffff0000Right-Click to show or hide the Options|r\n"..
-"|cff999999(Execution-Order: System)|r";
+"Various attack commands\n"..
+"Right-click the Options to set a new default action.\n"..
+"|cffff0000Left-click to activate the default action|r\n"..
+"|cff999999(Executed by: Raid, Party)|r\n\n"..
+"|cffff0000Right-click to show or hide the Options|r\n"..
+"|cff999999(Executed by: System)|r";
 
-MultiBot.tips.attack.attack = 
+MultiBot.tips.attack.attack =
 "Attack\n|cffffffff"..
-"With this Command the whole Raid or Party will attack your target.|r\n\n"..
-"|cffff0000Left-Click to execute Attack|r\n"..
-"|cff999999(Execution-Order: Raid, Party)|r\n\n"..
-"|cffff0000Right-Click to define as default Action|r\n"..
-"|cff999999(Execution-Order: System)|r";
+"The entire Party or Raid attacks your Target.|r\n\n"..
+"|cffff0000Left-click to activate Attack|r\n"..
+"|cff999999(Executed by: Raid, Party)|r\n\n"..
+"|cffff0000Right-click to set as default action|r\n"..
+"|cff999999(Executed by: System)|r";
 
-MultiBot.tips.attack.ranged = 
+MultiBot.tips.attack.ranged =
 "Ranged-Attack\n|cffffffff"..
-"With this Command the Ranged-Fighters will attack your target.|r\n\n"..
-"|cffff0000Left-Click to execute Ranged-Attack|r\n"..
-"|cff999999(Execution-Order: Raid, Party)|r\n\n"..
-"|cffff0000Right-Click to define as default Action|r\n"..
-"|cff999999(Execution-Order: System)|r";
+"All ranged attackers attack your Target.|r\n\n"..
+"|cffff0000Left-click to activate Ranged-Attack|r\n"..
+"|cff999999(Executed by: Raid, Party)|r\n\n"..
+"|cffff0000Right-click to set as default action|r\n"..
+"|cff999999(Executed by: System)|r";
 
-MultiBot.tips.attack.melee = 
+MultiBot.tips.attack.melee =
 "Melee-Attack\n|cffffffff"..
-"With this Command the Melee-Fighters will attack your target.|r\n\n"..
-"|cffff0000Left-Click to execute Melee-Attack|r\n"..
-"|cff999999(Execution-Order: Raid, Party)|r\n\n"..
-"|cffff0000Right-Click to define as default Action|r\n"..
-"|cff999999(Execution-Order: System)|r";
+"All melee attackers attack your Target.|r\n\n"..
+"|cffff0000Left-click to activate Melee-Attack|r\n"..
+"|cff999999(Executed by: Raid, Party)|r\n\n"..
+"|cffff0000Right-click to set as default action|r\n"..
+"|cff999999(Executed by: System)|r";
 
 MultiBot.tips.attack.healer = 
 "Healer-Attack\n|cffffffff"..
@@ -928,6 +931,38 @@ MultiBot.tips.units.alliance =
 "|cffff0000Right-Click to bring all Group-Members offline|r\n"..
 "|cff999999(Execution-Order: System)|r";
 
+-- SLIDERS INTERFACE --
+
+MultiBot.tips.sliders.throttleinstalled =
+"MultiBot throttle installed";
+
+MultiBot.tips.sliders.frametitle =
+"MultiBot — Options";
+
+MultiBot.tips.sliders.actionsinter =
+"Automatic action intervals";
+
+MultiBot.tips.sliders.statsinter =
+"Stats ping interval";
+
+MultiBot.tips.sliders.talentsinter =
+"Auto talents interval";
+
+MultiBot.tips.sliders.invitsinter =
+"Invitation loop interval";
+
+MultiBot.tips.sliders.sortinter =
+"Sorting/refresh interval";
+
+MultiBot.tips.sliders.messpersec =
+"Messages per second";
+
+MultiBot.tips.sliders.maxburst =
+"Maximum burst";
+
+MultiBot.tips.sliders.rstbutn =
+"Reset";
+
 -- MAIN --
 
 MultiBot.tips.main.master =
@@ -938,6 +973,14 @@ MultiBot.tips.main.master =
 "|cff999999(Execution-Order: System)|r\n\n"..
 "|cffff0000Right-Click to drag and move MultiBot|r\n"..
 "|cff999999(Execution-Order: System)|r";
+
+MultiBot.tips.main.options =
+"Options-Switch\n|cffffffff"..
+"Opens the MultiBot settings panel with sliders for action intervals.\n"..
+"(Stats / Talents / Invite / Sort) and chat throttling (Messages per second / Burst).\n"..
+"Settings are saved per character.|r\n\n"..
+"|cffff0000Left-Click to open or close the options panel|r\n"..
+"|cff999999(Execution-Order: Interface)|r";
 
 MultiBot.tips.main.coords =
 "Reset-Coords\n|cffffffff"..

--- a/MultiBotOptions.lua
+++ b/MultiBotOptions.lua
@@ -1,0 +1,208 @@
+-- MultiBotOptions.lua
+-- print("MultiBotOptions.lua loaded")
+
+local PANEL_NAME = "MultiBotOptionsPanel"
+
+local function round(x, step) step = step or 1; return math.floor(x/step + 0.5)*step end
+
+local function makeSlider(parent, key, label, minV, maxV, step, y)
+  local name = PANEL_NAME .. "_" .. key .. "_Slider"
+  local s = CreateFrame("Slider", name, parent, "OptionsSliderTemplate")
+  s:SetPoint("TOPLEFT", 16, y)
+  s:SetMinMaxValues(minV, maxV)
+  s:SetValueStep(step)
+  if s.SetObeyStepOnDrag then s:SetObeyStepOnDrag(true) end
+  s:SetWidth(300)
+
+  _G[name .. "Text"]:SetText(label)
+  _G[name .. "Low"]:SetText(string.format("%.1f s", minV))
+  _G[name .. "High"]:SetText(string.format("%.1f s", maxV))
+
+  local val = parent:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+  val:SetPoint("TOP", s, "BOTTOM", 0, 0)
+
+  local function refresh()
+    local v = MultiBot.GetTimer(key)
+    s:SetValue(v)
+    val:SetText(string.format("%.1f s", v))
+  end
+
+  s:SetScript("OnValueChanged", function(self, v)
+    v = round(v, step)
+    self:SetValue(v)
+    MultiBot.SetTimer(key, v)
+    val:SetText(string.format("%.1f s", v))
+  end)
+
+  s._refresh = refresh
+  return s
+end
+
+-- Fabrique pour les sliders throttle (utilise Get/Set dédiés)
+local function makeThrottleSlider(parent, key, label, minV, maxV, step, y)
+  local name = PANEL_NAME .. "_" .. key .. "_Slider"
+  local s = CreateFrame("Slider", name, parent, "OptionsSliderTemplate")
+  s:SetPoint("TOPLEFT", 16, y)
+  s:SetMinMaxValues(minV, maxV)
+  s:SetValueStep(step)
+  if s.SetObeyStepOnDrag then s:SetObeyStepOnDrag(true) end
+  s:SetWidth(300)
+
+  _G[name .. "Text"]:SetText(label)
+  _G[name .. "Low"]:SetText(tostring(minV))
+  _G[name .. "High"]:SetText(tostring(maxV))
+
+  local val = parent:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+  val:SetPoint("TOP", s, "BOTTOM", 0, 0)
+
+  local function getValue()
+    if key == "thr_rate" then return MultiBot.GetThrottleRate() else return MultiBot.GetThrottleBurst() end
+  end
+  local function setValue(v)
+    if key == "thr_rate" then MultiBot.SetThrottleRate(v) else MultiBot.SetThrottleBurst(v) end
+  end
+
+  local function refresh()
+    local v = getValue()
+    s:SetValue(v)
+    val:SetText(tostring(v))
+  end
+
+  s:SetScript("OnValueChanged", function(self, v)
+    v = round(v, step)
+    self:SetValue(v)
+    setValue(v)
+    val:SetText(tostring(v))
+  end)
+
+  s._refresh = refresh
+  return s
+end
+
+function MultiBot.BuildOptionsPanel()
+  if MultiBot._optionsBuilt then return end
+
+  -- parent = UIParent (pas InterfaceOptionsFramePanelContainer sur 3.3.5)
+  local panel = CreateFrame("Frame", PANEL_NAME, UIParent)
+  panel.name = "MultiBot"
+  panel:Hide()
+
+  panel:SetScript("OnShow", function(self)
+    if self._initialized then return end
+    self._initialized = true
+
+    local title = self:CreateFontString(nil, "ARTWORK", "GameFontNormalLarge")
+    title:SetPoint("TOPLEFT", 16, -16)
+    title:SetText(MultiBot.tips.sliders.frametitle)
+
+    local sub = self:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    sub:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -6)
+    sub:SetText(MultiBot.tips.sliders.actionsinter)
+
+    -- Sliders : on les crée puis on les ANCRE sous le sous-titre pour éviter tout chevauchement
+    self.s_stats  = makeSlider(self, "stats",  MultiBot.tips.sliders.statsinter,           5, 300, 1,   -40)
+    self.s_talent = makeSlider(self, "talent", MultiBot.tips.sliders.talentsinter,         1,  30, 0.5, -90)
+    self.s_invite = makeSlider(self, "invite", MultiBot.tips.sliders.invitsinter, 1,  60, 1,   -140)
+    self.s_sort   = makeSlider(self, "sort",   MultiBot.tips.sliders.sortinter, 0.2,10, 0.2, -190)
+
+    -- Throttle (NOUVEAU)
+    self.s_thr_rate  = makeThrottleSlider(self, "thr_rate",  MultiBot.tips.sliders.messpersec, 1, 20, 1, 0)
+    self.s_thr_burst = makeThrottleSlider(self, "thr_burst", MultiBot.tips.sliders.maxburst,    1, 50, 1, 0)
+
+    -- Ré-ancrage vertical
+    self.s_stats:ClearAllPoints()
+    self.s_stats:SetPoint("TOPLEFT", sub, "BOTTOMLEFT", 0, -16)
+    
+    self.s_talent:ClearAllPoints()
+    self.s_talent:SetPoint("TOPLEFT", self.s_stats, "BOTTOMLEFT", 0, -36)
+    
+    self.s_invite:ClearAllPoints()
+    self.s_invite:SetPoint("TOPLEFT", self.s_talent, "BOTTOMLEFT", 0, -36)
+    
+    self.s_sort:ClearAllPoints()
+    self.s_sort:SetPoint("TOPLEFT", self.s_invite, "BOTTOMLEFT", 0, -36)
+    
+    self.s_thr_rate:ClearAllPoints()
+    self.s_thr_rate:SetPoint("TOPLEFT", self.s_sort, "BOTTOMLEFT", 0, -36)
+    
+    self.s_thr_burst:ClearAllPoints()
+    self.s_thr_burst:SetPoint("TOPLEFT", self.s_thr_rate, "BOTTOMLEFT", 0, -36)
+
+    -- Bouton : descendu sous le dernier slider
+    local btn = CreateFrame("Button", nil, self, "UIPanelButtonTemplate")
+    btn:SetSize(140, 22)
+    btn:ClearAllPoints()
+    btn:SetPoint("TOPLEFT", self.s_thr_burst, "BOTTOMLEFT", 0, -24)
+    btn:SetText(MultiBot.tips.sliders.rstbutn)
+    btn:SetScript("OnClick", function()
+      -- Timers
+      MultiBot.SetTimer("stats",  45)
+      MultiBot.SetTimer("talent", 3)
+      MultiBot.SetTimer("invite", 5)
+      MultiBot.SetTimer("sort",   1)
+      self.s_stats._refresh(); self.s_talent._refresh(); self.s_invite._refresh(); self.s_sort._refresh()
+    
+      -- Throttle (défauts)
+      MultiBot.SetThrottleRate(5)
+      MultiBot.SetThrottleBurst(8)
+      self.s_thr_rate._refresh(); self.s_thr_burst._refresh()
+    end)
+
+    self.s_stats._refresh(); self.s_talent._refresh(); self.s_invite._refresh(); self.s_sort._refresh()
+    self.s_thr_rate._refresh(); self.s_thr_burst._refresh()
+  end)
+
+  -- Enregistre proprement dans le menu Options (avec fallback 3.3.5)
+  if type(InterfaceOptions_AddCategory) == "function" then
+    InterfaceOptions_AddCategory(panel)
+  elseif type(InterfaceOptionsFrame_AddCategory) == "function" then
+    InterfaceOptionsFrame_AddCategory(panel)
+  elseif type(INTERFACEOPTIONS_ADDONCATEGORIES) == "table" then
+    table.insert(INTERFACEOPTIONS_ADDONCATEGORIES, panel)
+  end
+
+  MultiBot._optionsPanel = panel   -- garder une référence pour /mbopt
+  MultiBot._optionsBuilt = true
+  -- print("MultiBotOptions: panel registered")
+end
+
+-- Slash pour ouvrir le panneau (double appel nécessaire sur 3.3.5 parfois)
+SLASH_MULTIBOTOPTIONS1 = "/mbopt"
+SlashCmdList["MULTIBOTOPTIONS"] = function()
+  if not MultiBot._optionsBuilt then
+    if MultiBot.BuildOptionsPanel then MultiBot.BuildOptionsPanel() end
+  end
+  local p = MultiBot._optionsPanel
+  if p and InterfaceOptionsFrame_OpenToCategory then
+    InterfaceOptionsFrame_OpenToCategory(p)
+    InterfaceOptionsFrame_OpenToCategory(p)
+  elseif p then
+    -- Fallback très simple : affiche juste le frame si l’API n’existe pas
+    p:Show()
+  end
+end
+
+-- Ouvre/ferme le panneau d'options. Retourne true si ouvert, false si fermé.
+function MultiBot.ToggleOptionsPanel()
+  if not MultiBot._optionsBuilt and MultiBot.BuildOptionsPanel then
+    MultiBot.BuildOptionsPanel()
+  end
+  local p = MultiBot._optionsPanel
+  if not p then return false end
+
+  local io = InterfaceOptionsFrame
+  -- Si notre panneau est déjà affiché, on ferme la fenêtre d’options
+  if io and io:IsShown() and p:IsShown() then
+    HideUIPanel(io)
+    return false
+  end
+
+  -- Sinon on l’ouvre (double appel nécessaire sur 3.3.5)
+  if InterfaceOptionsFrame_OpenToCategory then
+    InterfaceOptionsFrame_OpenToCategory(p)
+    InterfaceOptionsFrame_OpenToCategory(p)
+  else
+    p:Show()
+  end
+  return true
+end

--- a/MultiBotThrottle.lua
+++ b/MultiBotThrottle.lua
@@ -1,0 +1,63 @@
+-- MultiBotThrottle.lua
+-- print("MultiBotThrottle.lua loaded")
+MultiBot = MultiBot or {}
+
+-- pack/unpack avec longueur n (pour gérer les nil au milieu)
+local function pack(...)
+  return { n = select('#', ...), ... }
+end
+
+function MultiBot.Throttle_Init()
+  if MultiBot._throttleInited then return end
+
+  local orig_SendChatMessage = SendChatMessage
+
+  -- Valeurs par défaut depuis la DB si présentes
+  local rate  = 5
+  local burst = 8
+  if MultiBotDB and MultiBotDB.throttle then
+    if type(MultiBotDB.throttle.rate)  == "number" and MultiBotDB.throttle.rate  > 0 then rate  = MultiBotDB.throttle.rate  end
+    if type(MultiBotDB.throttle.burst) == "number" and MultiBotDB.throttle.burst > 0 then burst = MultiBotDB.throttle.burst end
+  end
+
+  local RATE_PER_SEC, BURST = rate, burst
+  local tokens = BURST
+  local queue = {}
+
+  -- Frame de vidage
+  local f = CreateFrame("Frame")
+  f:Show()
+  f:SetScript("OnUpdate", function(_, dt)
+    tokens = math.min(BURST, tokens + RATE_PER_SEC * dt)
+    while tokens >= 1 and #queue > 0 do
+      local item = table.remove(queue, 1)
+      -- IMPORTANT: passer la borne haute à unpack (Lua 5.1)
+      orig_SendChatMessage(unpack(item.args, 1, item.args.n))
+      tokens = tokens - 1
+
+      -- Debug optionnel: ne log que les messages de test [MB_TEST]
+      if item.args and type(item.args[1]) == "string" and string.find(item.args[1], "^%[MB_TEST%]") then
+        if DEFAULT_CHAT_FRAME and GetTime then
+          DEFAULT_CHAT_FRAME:AddMessage(string.format("|cff88ff88[Throttle]|r %.2fs -> %s", GetTime(), item.args[1]))
+        end
+      end
+    end
+  end)
+
+  -- Surcharge globale (enfile tous les envois)
+  SendChatMessage = function(msg, chatType, language, target)
+    queue[#queue+1] = { args = pack(msg, chatType, language, target) }
+  end
+
+  -- API interne pour MAJ live depuis les sliders
+  MultiBot._ThrottleStats = function(newRate, newBurst)
+    if type(newRate)  == "number" and newRate  > 0 then RATE_PER_SEC = newRate end
+    if type(newBurst) == "number" and newBurst > 0 then BURST = newBurst; tokens = math.min(tokens, BURST) end
+  end
+
+  MultiBot._throttleInited = true
+  MultiBot._throttleOrig   = orig_SendChatMessage
+  if DEFAULT_CHAT_FRAME then
+    DEFAULT_CHAT_FRAME:AddMessage(string.format(MultiBot.tips.sliders.throttleinstalled .. " (%.0f msg/s, rafale %d)", RATE_PER_SEC, BURST))
+  end
+end


### PR DESCRIPTION
### Why
Previously, several automatic actions used **hard-coded intervals** (stats/talents/invite/sort) and the addon could produce **chat bursts** (large parties/raids).

### This PR adds:

- a **settings panel** so players can adjust those intervals without touching code,
- a **global chat throttle** to smooth SendChatMessage calls,
- an **“Options” button** on the MultiBot bar for one-click access.

All defaults preserve the **original behavior** .

### What’s included

- **New Options panel** (ESC → Interface → AddOns → MultiBot) or button in Multibot Bar

- Sliders for action intervals: **Stats, Talents, Invite, Sort**
- Sliders for throttling: **Messages per second** and **Burst size**
- **Per-character** persistence (SavedVariablesPerCharacter)

- **Global chat throttling** (token-bucket) applied to **all** SendChatMessage calls

- Defaults: **5 msg/s, burst 8**
- Lua 5.1-safe (pack/unpack with explicit upper bound)
- Prints a short “throttle installed” line on load

- **“Options” button** on the MultiBot bar

- Icon: inv_misc_gear_02 (gear)
- Greyed by default; Left-Click toggles panel and visual state

- **3.3.5a compatibility polish**

- Safe anchoring (no header overlap)
- Call SetObeyStepOnDrag **only if available**
- Fallbacks for InterfaceOptions_AddCategory and double OpenToCategory


### File changes (summary)
**New**

- MultiBotConfig.lua

- Timer defaults: stats=45, talent=3, invite=5, sort=1
- Throttle defaults: rate=5, burst=8
- API: GetTimer/SetTimer, ApplyTimerChanges, ApplyTimersToRuntime
- Throttle API: GetThrottleRate/SetThrottleRate, GetThrottleBurst/SetThrottleBurst

- MultiBotOptions.lua

- Builds the options panel (6 sliders) + Reset button (restores 45/3/5/1 and 5/8)
- MultiBot.ToggleOptionsPanel() to open/close from code/UI

- MultiBotThrottle.lua

- Global hook for SendChatMessage with queue + token bucket
- Lua 5.1 fix: argument pack/unpack with length to preserve nil slots (e.g., WHISPER)
- Live updates via MultiBot._ThrottleStats(rate, burst); logs “throttle installed …” on init


### Modified

- MultiBot.toc

MultiBot.lua
MultiBotConfig.lua
MultiBotOptions.lua
MultiBotThrottle.lua

- Keep: ## SavedVariablesPerCharacter: MultiBotSave, MultiBotDB and ## SavedVariables: MultiBotGlobalSave


- MultiBotHandler.lua

- In the ADDON_LOADED handler (for “MultiBot”):
 call MultiBot.Config_Ensure(), ApplyTimersToRuntime(), BuildOptionsPanel(), Throttle_Init()
- (Dev helpers optionally added during testing: /mbopt, /mbdump, /mbset, /mbspam, /mbcheck, /mbreset)

- MultiBotInit.lua

- Added “Options” button above “Actions” using icon inv_misc_gear_02; left-click toggles panel and greys/un-greys the button
- Added tooltips


### New user-visible features

**- Options UI**

- 4 interval sliders (Stats/Talents/Invite/Sort, in seconds)
- 2 throttle sliders (Messages per second / Burst)
- Reset button to restore defaults
- Settings saved per character

**- Global throttling**

- Smooths all chat sends (/say, whispers, .playerbot commands, etc.)
- Prevents bursts during invites/raid sorting/command spam
- Adjustable from the UI (takes effect immediately)

**- Toolbar “Options” button**

- One-click access; visual state reflects open/closed panel


### Backward compatibility

- No breaking changes. Defaults match original behavior.
- If the user never opens the panel, the addon behaves exactly as before.
- Throttle defaults (5/8) are safe for typical usage.


### How to test

1. Launch client and /reload

- Chat should print: “MultiBot throttle installed (5 msg/s, burst 8)”

2. Open ESC → Interface → AddOns → MultiBot (or /mbopt)

- Adjust all 6 sliders; press Reset to restore 45/3/5/1 and 5/8

3. Verify timers take effect

- Lower Stats (e.g., 10s) → stats pings should occur ~every 10s (not 45s)
- Start a large invite → observe messages flow steadily (no burst)

4. (Dev) Use /mbspam 20 to visualize throttling according to Messages/s and Burst

<img width="1294" height="790" alt="image" src="https://github.com/user-attachments/assets/cc818e42-9715-4cc2-bee2-572a7b026152" />

