### PR TITLE
GM-aware UI — gray out GM-only controls (with tooltip) - auto-detect account level (multi-locale) -  configurable threshold

### DIFF
--- a/MultiBotHandler.lua
+++ b/MultiBotHandler.lua
@@ -350,12 +350,20 @@ MultiBot:SetScript("OnEvent", function()
 	-- CHAT:SYSTEM --
 	
 	if(event == "CHAT_MSG_SYSTEM") then
-		if(MultiBot.isInside(arg1, "Accountlevel", "account level", "niveau de compte", "等级")) then
+		--[[if(MultiBot.isInside(arg1, "Accountlevel", "account level", "niveau de compte", "等级")) then
 			local tLevel = tonumber(MultiBot.doSplit(arg1, ": ")[2])
 			if(tLevel ~= nil) then MultiBot.GM = tLevel > 1 end
 			MultiBot.RaidPool("player")
-		end
-		
+		end]]--
+
+		-- Détection générique du niveau de compte (toutes langues prises en charge via patrons)
+        do
+          local msg = arg1
+          if MultiBot.GM_DetectFromSystem and type(msg) == "string" then
+            MultiBot.GM_DetectFromSystem(msg)
+          end
+        end
+
 		if(MultiBot.isInside(arg1, "Possible strategies")) then
 			local tStrategies = MultiBot.doSplit(arg1, ", ")
 			SendChatMessage("=== STRATEGIES ===", "SAY")
@@ -1356,3 +1364,10 @@ SlashCmdList["MBCHECK"] = function()
     tostring(SendChatMessage)
   ))
 end]]--
+
+SLASH_MBFAKEGM1 = "/mbfakegm"
+SlashCmdList["MBFAKEGM"] = function(msg)
+  local n = tonumber(msg or "") or 0
+  MultiBot.GM_DetectFromSystem(("Account level: %d"):format(n))
+  DEFAULT_CHAT_FRAME:AddMessage(("GM now: %s (lvl=%d, threshold=%d)"):format(tostring(MultiBot.GM), n, MultiBot.GM_THRESHOLD))
+end

--- a/MultiBotLanguage-deDE.lua
+++ b/MultiBotLanguage-deDE.lua
@@ -917,14 +917,48 @@ MultiBot.tips.units.inviteRaid40 =
 
 -- UNITS:ALL --
 
-MultiBot.tips.units.alliance = 
-"Alliance\n|cffffffff"..
-"Mit dieser Schaltfläche bringt Ihr alle Gruppenmitglieder online oder offline.\n"..
-"Möglicherweise kommt MultiBot mit der Geschwindigkeit nicht klar und verschluckt einige Botbars.\n\n"..
-"|cffff0000Linksklicken um die Gruppenmitglieder online zu bringen|r\n"..
-"|cff999999(Ausführreihenfolge: System)|r\n\n"..
-"|cffff0000Rechtsklicken um die Gruppenmitglieder offlien zu bringen|r\n"..
-"|cff999999(Ausführreihenfolge: System)|r";
+MultiBot.tips.units.alliance =
+"Alle PlayerBots ein-/ausloggen\n|cffffffff"..
+"Loggt alle PlayerBots ein oder aus, auf die du Zugriff hast.\n"..
+"Diese Funktion kann je nach Gesamtanzahl der PlayerBots einige Zeit benötigen,\n"..
+"um die Buttonleisten für jeden PlayerBot zu laden.\n\n"..
+"|cffff0000Linksklick, um alle PlayerBots einzuloggen|r\n"..
+"|cff999999(Ausgeführt von: System)|r\n\n"..
+"|cffff0000Rechtsklick, um alle PlayerBots auszuloggen|r\n"..
+"|cff999999(Ausgeführt von: System)|r";
+
+-- SLIDERS INTERFACE --
+
+MultiBot.tips.sliders.throttleinstalled =
+"MultiBot-Drossel installiert";
+
+MultiBot.tips.sliders.frametitle =
+"MultiBot — Optionen";
+
+MultiBot.tips.sliders.actionsinter =
+"Intervalle für automatische Aktionen";
+
+MultiBot.tips.sliders.statsinter =
+"Statistik-Ping-Intervall";
+
+MultiBot.tips.sliders.talentsinter =
+"Intervall für automatische Talente";
+
+MultiBot.tips.sliders.invitsinter =
+"Einladungs-Schleifenintervall";
+
+MultiBot.tips.sliders.sortinter =
+"Sortier-/Aktualisierungsintervall";
+
+MultiBot.tips.sliders.messpersec =
+"Nachrichten pro Sekunde";
+
+MultiBot.tips.sliders.maxburst =
+"Maximale Burst";
+
+MultiBot.tips.sliders.rstbutn =
+"Zurücksetzen";
+
 
 -- MAIN --
 
@@ -936,6 +970,14 @@ MultiBot.tips.main.master =
 "|cff999999(Ausführreihenfolge: System)|r\n\n"..
 "|cffff0000Rechtsklicken und halten um MultiBar zu verschieben|r\n"..
 "|cff999999(Ausführreihenfolge: System)|r";
+
+MultiBot.tips.main.options =
+"Optionen-Schalter\n|cffffffff"..
+"Öffnet das MultiBot-Einstellungsfenster mit Schiebereglern für Aktionsintervalle.\n"..
+"(Statistiken / Talente / Einladung / Sortieren) und Chat-Drosselung (Nachrichten pro Sekunde / Burst).\n"..
+"Einstellungen werden pro Charakter gespeichert.|r\n\n"..
+"|cffff0000Linksklick zum Öffnen oder Schließen des Optionsfensters|r\n"..
+"|cff999999(Ausführungsreihenfolge: Interface)|r";
 
 MultiBot.tips.main.coords =
 "Reset-Coords\n|cffffffff"..

--- a/MultiBotLanguage-enUS.lua
+++ b/MultiBotLanguage-enUS.lua
@@ -879,6 +879,38 @@ MultiBot.tips.units.alliance =
 "|cffff0000Right-click to log out all PlayerBots|r\n"..
 "|cff999999(Executed by: System)|r";
 
+-- SLIDERS INTERFACE --
+
+MultiBot.tips.sliders.throttleinstalled =
+"MultiBot throttle installed";
+
+MultiBot.tips.sliders.frametitle =
+"MultiBot — Options";
+
+MultiBot.tips.sliders.actionsinter =
+"Automatic action intervals";
+
+MultiBot.tips.sliders.statsinter =
+"Stats ping interval";
+
+MultiBot.tips.sliders.talentsinter =
+"Auto talents interval";
+
+MultiBot.tips.sliders.invitsinter =
+"Invitation loop interval";
+
+MultiBot.tips.sliders.sortinter =
+"Sorting/refresh interval";
+
+MultiBot.tips.sliders.messpersec =
+"Messages per second";
+
+MultiBot.tips.sliders.maxburst =
+"Maximum burst";
+
+MultiBot.tips.sliders.rstbutn =
+"Reset";
+
 -- MAIN --
 
 MultiBot.tips.main.master =
@@ -888,6 +920,14 @@ MultiBot.tips.main.master =
 "|cff999999(Executed by: System)|r\n\n"..
 "|cffff0000Right-click to drag and move MultiBot windows|r\n"..
 "|cff999999(Executed by: System)|r";
+
+MultiBot.tips.main.options =
+"Options-Switch\n|cffffffff"..
+"Opens the MultiBot settings panel with sliders for action intervals.\n"..
+"(Stats / Talents / Invite / Sort) and chat throttling (Messages per second / Burst).\n"..
+"Settings are saved per character.|r\n\n"..
+"|cffff0000Left-Click to open or close the options panel|r\n"..
+"|cff999999(Execution-Order: Interface)|r";
 
 MultiBot.tips.main.coords =
 "Reset Window Locations\n|cffffffff"..

--- a/MultiBotLanguage-esES.lua
+++ b/MultiBotLanguage-esES.lua
@@ -921,14 +921,48 @@ MultiBot.tips.units.inviteRaid40 =
 
   -- UNITS:ALL --
 
-MultiBot.tips.units.alliance = 
-"Alliance\n|cffffffff"..
-"Con este botón puedes poner en línea o desconectar a todos los miembros de tu grupo.\n"..
-"Tal vez MultiBot no pueda reaccionar lo suficientemente rápido y no muestre todas las barras de bots.\n\n"..
-"|cffff0000Clic izquierdo para poner en línea a todos los miembros del grupo|r\n"..
-"|cff999999(Orden de ejecución: Sistema)|r\n\n"..
-"|cffff0000Clic derecho para desconectar a todos los miembros del grupo|r\n"..
-"|cff999999(Orden de ejecución: Sistema)|r";
+MultiBot.tips.units.alliance =
+"Iniciar/Cerrar sesión de todos los PlayerBots\n|cffffffff"..
+"Inicia o cierra la sesión de todos los PlayerBots a los que tengas acceso.\n"..
+"Esta función puede tardar en llenar las barras de botones de cada PlayerBot,\n"..
+"dependiendo del número total de PlayerBots.\n\n"..
+"|cffff0000Clic izquierdo para iniciar sesión en todos los PlayerBots|r\n"..
+"|cff999999(Ejecutado por: Sistema)|r\n\n"..
+"|cffff0000Clic derecho para cerrar sesión en todos los PlayerBots|r\n"..
+"|cff999999(Ejecutado por: Sistema)|r";
+
+
+-- SLIDERS INTERFACE --
+
+MultiBot.tips.sliders.throttleinstalled =
+"Limitador de MultiBot instalado";
+
+MultiBot.tips.sliders.frametitle =
+"MultiBot — Opciones";
+
+MultiBot.tips.sliders.actionsinter =
+"Intervalos de acciones automáticas";
+
+MultiBot.tips.sliders.statsinter =
+"Intervalo de ping de estadísticas";
+
+MultiBot.tips.sliders.talentsinter =
+"Intervalo de talentos automáticos";
+
+MultiBot.tips.sliders.invitsinter =
+"Intervalo del bucle de invitaciones";
+
+MultiBot.tips.sliders.sortinter =
+"Intervalo de ordenación/actualización";
+
+MultiBot.tips.sliders.messpersec =
+"Mensajes por segundo";
+
+MultiBot.tips.sliders.maxburst =
+"Ráfaga máxima";
+
+MultiBot.tips.sliders.rstbutn =
+"Restablecer";
 
 -- MAIN --
 
@@ -940,6 +974,14 @@ MultiBot.tips.main.master =
 "|cff999999(Orden de ejecución: Sistema)|r\n\n"..
 "|cffff0000Clic derecho para mover MultiBot|r\n"..
 "|cff999999(Orden de ejecución: Sistema)|r";
+
+MultiBot.tips.main.options =
+"Interruptor de opciones\n|cffffffff"..
+"Abre el panel de configuración de MultiBot con controles deslizantes para los intervalos de acciones.\n"..
+"(Estadísticas / Talentos / Invitación / Ordenar) y la limitación del chat (Mensajes por segundo / Ráfaga).\n"..
+"La configuración se guarda por personaje.|r\n\n"..
+"|cffff0000Clic izquierdo para abrir o cerrar el panel de opciones|r\n"..
+"|cff999999(Orden de ejecución: Interfaz)|r";
 
 MultiBot.tips.main.coords =
 "Reset-Coords\n|cffffffff"..  -- Línea que se mantiene en inglés

--- a/MultiBotLanguage-frFR.lua
+++ b/MultiBotLanguage-frFR.lua
@@ -928,17 +928,49 @@ MultiBot.tips.units.inviteRaid40 =
 
 -- UNITS:ALL --
 
-MultiBot.tips.units.alliance = 
-"Alliance\n|cffffffff"..
-"Avec ce bouton, vous pouvez mettre en ligne ou hors ligne tous les membres de votre groupe.\n"..
-"Il se peut que MultiBot ne réagisse pas assez rapidement et n'affiche pas toutes les Botbars.\n\n"..
-"|cffff0000Clic gauche pour mettre en ligne tous les membres du groupe|r\n"..
-"|cff999999(Ordre d'exécution : Système)|r\n\n"..
-"|cffff0000Clic droit pour mettre hors ligne tous les membres du groupe|r\n"..
-"|cff999999(Ordre d'exécution : Système)|r";
+MultiBot.tips.units.alliance =
+"Connexion/Déconnexion de tous les PlayerBots\n|cffffffff"..
+"Connecte ou déconnecte tous les PlayerBots auxquels vous avez accès.\n"..
+"Cette fonction peut prendre du temps pour remplir les barres de boutons de chaque PlayerBot,\n"..
+"en fonction du nombre total de PlayerBots.\n\n"..
+"|cffff0000Clic gauche pour connecter tous les PlayerBots|r\n"..
+"|cff999999(Exécuté par : Système)|r\n\n"..
+"|cffff0000Clic droit pour déconnecter tous les PlayerBots|r\n"..
+"|cff999999(Exécuté par : Système)|r";
 
+-- SLIDERS INTERFACE --
 
--- PRINCIPAL --
+MultiBot.tips.sliders.throttleinstalled =
+"Limitation MultiBot installée";
+
+MultiBot.tips.sliders.frametitle =
+"MultiBot — Options";
+
+MultiBot.tips.sliders.actionsinter =
+"Intervalles des actions automatiques";
+
+MultiBot.tips.sliders.statsinter =
+"Intervalle ping des stats";
+
+MultiBot.tips.sliders.talentsinter =
+"Intervalle d’attribution auto des talents";
+
+MultiBot.tips.sliders.invitsinter =
+"Intervalle de la boucle d’invitations";
+
+MultiBot.tips.sliders.sortinter =
+"Intervalle de tri/rafraîchissement";
+
+MultiBot.tips.sliders.messpersec =
+"Messages par seconde";
+
+MultiBot.tips.sliders.maxburst =
+"Rafale maximale";
+
+MultiBot.tips.sliders.rstbutn =
+"Réinitialiser";
+
+-- MAIN --
 
 MultiBot.tips.main.master =
 "Contrôle Principal\n|cffffffff"..
@@ -948,6 +980,14 @@ MultiBot.tips.main.master =
 "|cff999999(Ordre d'exécution : Système)|r\n\n"..
 "|cffff0000Clic droit pour faire glisser et déplacer MultiBot|r\n"..
 "|cff999999(Ordre d'exécution : Système)|r";
+
+MultiBot.tips.main.options =
+"Options-Switch\n|cffffffff"..
+"Ouvre le panneau des paramètres MultiBot avec des curseurs pour les intervalles d’actions.\n"..
+"(Stats / Talents / Invitation / Tri) et la limitation du chat (Messages par seconde / Rafale).\n"..
+"Les paramètres sont enregistrés par personnage.|r\n\n"..
+"|cffff0000Clic gauche pour ouvrir ou fermer le panneau d’options|r\n"..
+"|cff999999(Ordre d’exécution : Interface)|r";
 
 MultiBot.tips.main.coords =
 "Réinitialiser les Coordonnées\n|cffffffff"..

--- a/MultiBotLanguage-koKR.lua
+++ b/MultiBotLanguage-koKR.lua
@@ -906,24 +906,57 @@ MultiBot.tips.units.inviteRaid25 =
 "|cffff0000팀원을 초대하려면 왼쪽 클릭|r\n"..
 "|cff999999(명령 실행: 시스템)|r";
 
-MultiBot.tips.units.inviteRaid40 =
-"40명으로 구성된 팀\n|cffffffff"..
-"이 버튼을 사용하여 팀을 구성하세요.\n"..
-"이 기능은 클래스 필터를 무시하고 선택한 팀 목록에서 유닛을 가져옵니다.\n"..
-"팀 목록이 끝나거나 팀 구성원이 40명이 되면 중단됩니다.|r\n\n"..
-"|cffff0000팀원을 초대하려면 왼쪽 클릭|r\n"..
-"|cff999999(명령 실행: 시스템)|r";
+MultiBot.tips.units.alliance =
+"모든 PlayerBot 로그인/로그아웃\n|cffffffff"..
+"접근 권한이 있는 모든 PlayerBot을 로그인하거나 로그아웃합니다.\n"..
+"이 기능은 PlayerBot의 총 수에 따라 각 PlayerBot의 버튼 바를 채우는 데 시간이 걸릴 수 있습니다.\n\n"..
+"|cffff0000왼쪽 클릭: 모든 PlayerBot 로그인|r\n"..
+"|cff999999(실행 주체: 시스템)|r\n\n"..
+"|cffff0000오른쪽 클릭: 모든 PlayerBot 로그아웃|r\n"..
+"|cff999999(실행 주체: 시스템)|r";
 
 -- UNITS:ALL --
 
 MultiBot.tips.units.alliance = 
-"Alliance\n|cffffffff"..
-"With this Button you can bring all you Group-Members online or offline.\n"..
-"Maybe MultiBot wont be able to react fast enough and will not show all Botbars.\n\n"..
-"|cffff0000Left-Click to bring all Group-Members online|r\n"..
-"|cff999999(Execution-Order: System)|r\n\n"..
-"|cffff0000Right-Click to bring all Group-Members offline|r\n"..
-"|cff999999(Execution-Order: System)|r";
+"얼라이언스 / 호드\n|cffffffff"..
+"이 버튼을 사용하면 모든 파티원을 온라인 또는 오프라인 상태로 전환할 수 있습니다.\n"..
+"MultiBot이 충분히 빠르게 반응하지 못해 모든 봇바를 표시하지 못할 수도 있습니다.\n\n"..
+"|cffff0000왼쪽 클릭: 모든 파티원을 온라인 상태로 전환|r\n"..
+"|cff999999(실행 순서: 시스템)|r\n\n"..
+"|cffff0000오른쪽 클릭: 모든 파티원을 오프라인 상태로 전환|r\n"..
+"|cff999999(실행 순서: 시스템)|r";
+
+-- SLIDERS INTERFACE --
+
+MultiBot.tips.sliders.throttleinstalled =
+"MultiBot 제한이 설치되었습니다";
+
+MultiBot.tips.sliders.frametitle =
+"MultiBot — 옵션";
+
+MultiBot.tips.sliders.actionsinter =
+"자동 작업 간격";
+
+MultiBot.tips.sliders.statsinter =
+"통계 핑 간격";
+
+MultiBot.tips.sliders.talentsinter =
+"자동 특성 간격";
+
+MultiBot.tips.sliders.invitsinter =
+"초대 루프 간격";
+
+MultiBot.tips.sliders.sortinter =
+"정렬/새로고침 간격";
+
+MultiBot.tips.sliders.messpersec =
+"초당 메시지 수";
+
+MultiBot.tips.sliders.maxburst =
+"최대 버스트";
+
+MultiBot.tips.sliders.rstbutn =
+"초기화";
 
 -- MAIN --
 
@@ -935,6 +968,14 @@ MultiBot.tips.main.master =
 "|cff999999(명령 실행: 시스템)|r\n\n"..
 "|cffff0000마우스 오른쪽 버튼을 클릭하여 MultiBot을 드래그하여 이동합니다.|r\n"..
 "|cff999999(명령 실행: 시스템)|r";
+
+MultiBot.tips.main.options =
+"옵션 전환\n|cffffffff"..
+"작업 간격 슬라이더가 있는 MultiBot 설정 패널을 엽니다.\n"..
+"(통계 / 특성 / 초대 / 정렬) 및 채팅 제한 (초당 메시지 수 / 버스트).\n"..
+"설정은 캐릭터별로 저장됩니다.|r\n\n"..
+"|cffff0000왼쪽 클릭으로 옵션 패널 열기/닫기|r\n"..
+"|cff999999(실행 순서: 인터페이스)|r";
 
 MultiBot.tips.main.coords =
 "좌표 재설정\n|cffffffff"..

--- a/MultiBotLanguage-ruRU.lua
+++ b/MultiBotLanguage-ruRU.lua
@@ -918,14 +918,47 @@ MultiBot.tips.units.inviteRaid40 =
 
 -- UNITS:ALL --
 
-MultiBot.tips.units.alliance = 
-"Alliance\n|cffffffff"..
-"With this Button you can bring all you Group-Members online or offline.\n"..
-"Maybe MultiBot wont be able to react fast enough and will not show all Botbars.\n\n"..
-"|cffff0000Left-Click to bring all Group-Members online|r\n"..
-"|cff999999(Execution-Order: System)|r\n\n"..
-"|cffff0000Right-Click to bring all Group-Members offline|r\n"..
-"|cff999999(Execution-Order: System)|r";
+MultiBot.tips.units.alliance =
+"Iniciar/Cerrar sesión de todos los PlayerBots\n|cffffffff"..
+"Inicia o cierra la sesión de todos los PlayerBots a los que tengas acceso.\n"..
+"Esta función puede tardar en llenar las barras de botones de cada PlayerBot,\n"..
+"dependiendo del número total de PlayerBots.\n\n"..
+"|cffff0000Clic izquierdo para iniciar sesión en todos los PlayerBots|r\n"..
+"|cff999999(Ejecutado por: Sistema)|r\n\n"..
+"|cffff0000Clic derecho para cerrar sesión en todos los PlayerBots|r\n"..
+"|cff999999(Ejecutado por: Sistema)|r";
+
+-- SLIDERS INTERFACE --
+
+MultiBot.tips.sliders.throttleinstalled =
+"Ограничитель MultiBot установлен";
+
+MultiBot.tips.sliders.frametitle =
+"MultiBot — Опции";
+
+MultiBot.tips.sliders.actionsinter =
+"Интервалы автоматических действий";
+
+MultiBot.tips.sliders.statsinter =
+"Интервал пинга статистики";
+
+MultiBot.tips.sliders.talentsinter =
+"Интервал автораспределения талантов";
+
+MultiBot.tips.sliders.invitsinter =
+"Интервал цикла приглашений";
+
+MultiBot.tips.sliders.sortinter =
+"Интервал сортировки/обновления";
+
+MultiBot.tips.sliders.messpersec =
+"Сообщений в секунду";
+
+MultiBot.tips.sliders.maxburst =
+"Максимальный рывок";
+
+MultiBot.tips.sliders.rstbutn =
+"Сброс";
 
 -- MAIN --
 
@@ -937,6 +970,14 @@ MultiBot.tips.main.master =
 "|cff999999(Порядок выполнения: Система)|r\n\n"..
 "|cffff0000Правый клик - переместить MultiBot|r\n"..
 "|cff999999(Порядок выполнения: Система)|r";
+
+MultiBot.tips.main.options =
+"Переключатель опций\n|cffffffff"..
+"Открывает панель настроек MultiBot с ползунками для интервалов действий.\n"..
+"(Статистика / Таланты / Приглашение / Сортировка) и ограничения чата (Сообщений в секунду / Рывок).\n"..
+"Настройки сохраняются для каждого персонажа.|r\n\n"..
+"|cffff0000ЛКМ — открыть или закрыть панель опций|r\n"..
+"|cff999999(Порядок выполнения: Интерфейс)|r";
 
 MultiBot.tips.main.coords =
 "Сброс координат\n|cffffffff"..

--- a/MultiBotLanguage-zhCN.lua
+++ b/MultiBotLanguage-zhCN.lua
@@ -917,16 +917,48 @@ MultiBot.tips.units.inviteRaid40 =
 
 -- UNITS:ALL --
 
-MultiBot.tips.units.alliance = 
-"Alliance\n|cffffffff"..
-"With this Button you can bring all you Group-Members online or offline.\n"..
-"Maybe MultiBot wont be able to react fast enough and will not show all Botbars.\n\n"..
-"|cffff0000Left-Click to bring all Group-Members online|r\n"..
-"|cff999999(Execution-Order: System)|r\n\n"..
-"|cffff0000Right-Click to bring all Group-Members offline|r\n"..
-"|cff999999(Execution-Order: System)|r";
+MultiBot.tips.units.alliance =
+"登录/登出所有 PlayerBot\n|cffffffff"..
+"登录或登出你有权限访问的所有 PlayerBot。\n"..
+"根据 PlayerBot 的总数量，此功能可能需要一些时间来填充每个 PlayerBot 的按钮栏。\n\n"..
+"|cffff0000左键点击：登录所有 PlayerBot|r\n"..
+"|cff999999（执行者：系统）|r\n\n"..
+"|cffff0000右键点击：登出所有 PlayerBot|r\n"..
+"|cff999999（执行者：系统）|r";
 
--- 主菜单 --
+-- SLIDERS INTERFACE --
+
+MultiBot.tips.sliders.throttleinstalled =
+"已安装 MultiBot 限速";
+
+MultiBot.tips.sliders.frametitle =
+"MultiBot — 选项";
+
+MultiBot.tips.sliders.actionsinter =
+"自动操作间隔";
+
+MultiBot.tips.sliders.statsinter =
+"统计延迟间隔";
+
+MultiBot.tips.sliders.talentsinter =
+"自动天赋间隔";
+
+MultiBot.tips.sliders.invitsinter =
+"邀请循环间隔";
+
+MultiBot.tips.sliders.sortinter =
+"排序/刷新间隔";
+
+MultiBot.tips.sliders.messpersec =
+"每秒消息数";
+
+MultiBot.tips.sliders.maxburst =
+"最大突发数";
+
+MultiBot.tips.sliders.rstbutn =
+"重置";
+
+-- MAIN --
 
 MultiBot.tips.main.master =
 "主控制面板\n|cffffffff"..
@@ -936,6 +968,14 @@ MultiBot.tips.main.master =
 "|cff999999(执行命令: 系统)|r\n\n"..
 "|cffff0000右键单击拖动和移动 MultiBot|r\n"..
 "|cff999999(执行命令: 系统)|r";
+
+MultiBot.tips.main.options =
+"选项切换\n|cffffffff"..
+"打开 MultiBot 设置面板，带有用于操作间隔的滑块。\n"..
+"(统计 / 天赋 / 邀请 / 排序) 以及聊天限速（每秒消息数 / 突发数）。\n"..
+"设置按角色单独保存。|r\n\n"..
+"|cffff0000左键单击以打开或关闭选项面板|r\n"..
+"|cff999999（执行顺序：界面）|r";
 
 MultiBot.tips.main.coords =
 "重置坐标\n|cffffffff"..


### PR DESCRIPTION
### Why
GM actions were visible and clickable for non-GM players, which could confuse users and trigger server errors. This PR makes GM-only controls self-aware: they gray out with a clear tooltip when the player lacks permissions, and automatically enable when the client sees the account level message from the server.

### What’s included

- GM core in MultiBot.lua

- MultiBot.SetGM(isGM) + MultiBot.ApplyGMVisibility() (invoked on changes)
- Gray mode: keeps layout, desaturates icon, lowers alpha; clicks are blocked
- Tooltip on hover: “You need GM rights to use this feature.”
- MultiBot.RegisterGMControl(widget) to mark any button/frame as GM-only (one-liner)

- Account level auto-detection (multi-locale)

- MultiBot.ParseAccountLevel(msg) + MultiBot.GM_DetectFromSystem(msg)
- Pattern set for EN/FR/ES/DE/RU/ZH/KO plus safe fallbacks (e.g., “…: 3”)
- Default threshold: MultiBot.GM_THRESHOLD = 2 (treat level ≥2 as GM for this addon)
- Optional debug (MultiBot.DEBUG_GM) to print parsed level and current threshold

- Handler integration

In the CHAT_MSG_SYSTEM branch, the hard-coded string checks were replaced by a single call to MultiBot.GM_DetectFromSystem(arg1).

Localization

- Added MultiBot.tips.gm_required = "You need GM rights to use this feature." (EN).
(Other locales can add their string in their language files.)

How to mark a control as GM-only
After creating a button/frame, register it:


### Configuration
Threshold (default 3). you can set it in file Multibot.lua:

`MultiBot.GM_THRESHOLD = 3`

### Backward compatibility

- Non-GM users no longer trigger protected actions by accident; controls are visibly disabled with an explanatory tooltip.
- GM users experience the same behavior as before once their account level is detected.
- No impact on existing layouts (gray mode keeps spacing).

### Testing

1. Log in and wait for the system line (e.g., “Your account level is: 2/3”).
Optionally enable MultiBot.DEBUG_GM = true to see parsed values.

2. Hover a GM-only button as non-GM → it’s grayed and shows the tooltip; clicks do nothing.

3. Become GM (or adjust threshold) → the same button becomes active immediately.

### Files touched

- MultiBot.lua: GM core (gray mode + tooltip), account-level parser & detector, threshold
- MultiBotHandler.lua: replace hard-coded string check with MultiBot.GM_DetectFromSystem(arg1)
- MultiBotLanguage-enUS.lua: MultiBot.tips.gm_required

Result: GM-only actions are clearly gated, self-explanatory, and automatically reflect the player’s permissions across all supported locales.
